### PR TITLE
Fix relative-import false positive, dogfood, CI hygiene

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: py${{ matrix.py }} / flake8 ${{ matrix.flake8 }}
@@ -47,7 +50,7 @@ jobs:
         run: uv run --no-sync pytest --cov-report=xml
 
       - name: Publish coverage report
+        if: matrix.py == '3.14' && matrix.flake8 == 'latest'
         uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          verbose: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,8 @@ repos:
     rev: 7.3.0
     hooks:
       - id: flake8
+        additional_dependencies:
+          - flake8-datetime-import
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.48.0

--- a/src/flake8_datetime_import.py
+++ b/src/flake8_datetime_import.py
@@ -26,10 +26,11 @@ class Visitor(ast.NodeVisitor):
         self.problems = []
 
     def visit_ImportFrom(self, node):
-        if node.module == "datetime":
-            self.problems.append((node.lineno, node.col_offset, "DTI100"))
-        if node.module == "time":
-            self.problems.append((node.lineno, node.col_offset, "DTI200"))
+        if node.level == 0:
+            if node.module == "datetime":
+                self.problems.append((node.lineno, node.col_offset, "DTI100"))
+            if node.module == "time":
+                self.problems.append((node.lineno, node.col_offset, "DTI200"))
 
         self.generic_visit(node)
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -90,3 +90,38 @@ def test_DTI201_import_time_not_as_tm(code):
 def test_import_time_as_tm():
     result = run_plugin("import time as tm")
     assert result == set()
+
+
+@pytest.mark.parametrize(
+    "code",
+    [
+        "from .datetime import foo",
+        "from ..datetime import foo",
+        "from .time import foo",
+        "from ..time import foo",
+    ],
+)
+def test_relative_imports_not_flagged(code):
+    assert run_plugin(code) == set()
+
+
+@pytest.mark.parametrize(
+    "code",
+    [
+        "from foo.datetime import bar",
+        "from foo.time import bar",
+        "from pkg.subpkg.datetime import bar",
+    ],
+)
+def test_nested_package_imports_not_flagged(code):
+    assert run_plugin(code) == set()
+
+
+def test_combined_import_flags_both():
+    result = run_plugin("import datetime, time")
+    assert result == {
+        "1:0 DTI101 `datetime` imported without aliasing as `dt`. "
+        "Expected `import datetime as dt`.",
+        "1:0 DTI201 `time` imported without aliasing as `tm`. "
+        "Expected `import time as tm`.",
+    }


### PR DESCRIPTION
## Bug fix
- `from .datetime import foo` and `from ..time import bar` were incorrectly flagged as DTI100/DTI200. Visitor now skips relative imports (where `node.level > 0`).

## Tests
- Relative imports (single + multi dot)
- Nested package imports (`from foo.datetime import bar`) — characterization test, was already correct
- Combined imports (`import datetime, time`) — characterization test, fires both codes

## Dogfooding
- Pre-commit flake8 hook now loads `flake8-datetime-import` as `additional_dependencies`. Plugin runs against its own source.

## CI hygiene
- Add `permissions: contents: read` to test workflow.
- Upload codecov from a single matrix job (`py3.14 / latest`) instead of all 10.

## Test plan
- [ ] CI matrix passes
- [ ] Codecov uploads exactly once